### PR TITLE
Make mjml-processor java14+ compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ project.version = scmVersion.version
 group 'com.wescale'
 
 apply plugin: 'java'
-apply plugin: 'maven'
 apply plugin: 'maven-publish'
 apply plugin: 'jacoco'
 
@@ -31,13 +30,19 @@ apply from: 'gradle/code-quality.gradle'
 apply from: 'gradle/releasing.gradle'
 apply from: 'gradle/spotless.gradle'
 
-sourceCompatibility = 1.8
+sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    testCompile group: 'commons-io', name: 'commons-io', version: '2.6'
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    implementation group: 'org.openjdk.nashorn', name: 'nashorn-core', version: '15.4'
+}
+
+jacoco {
+    toolVersion = "0.8.8"
 }

--- a/gradle/releasing.gradle
+++ b/gradle/releasing.gradle
@@ -50,6 +50,16 @@ bintray {
 
 }
 
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    classifier "sources"
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 publishing {
     publications {
         DefaultMavenPublication(MavenPublication) {
@@ -68,14 +78,4 @@ publishing {
             }
         }
     }
-}
-
-task sourcesJar(type: Jar) {
-  from sourceSets.main.allJava
-  classifier "sources"
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip

--- a/src/main/java/com/wescale/mjml/MjmlProcessor.java
+++ b/src/main/java/com/wescale/mjml/MjmlProcessor.java
@@ -15,7 +15,7 @@
  */
 package com.wescale.mjml;
 
-import jdk.nashorn.api.scripting.JSObject;
+import org.openjdk.nashorn.api.scripting.JSObject;
 
 import javax.script.*;
 

--- a/src/main/java/com/wescale/mjml/MjmlProcessorResult.java
+++ b/src/main/java/com/wescale/mjml/MjmlProcessorResult.java
@@ -15,7 +15,7 @@
  */
 package com.wescale.mjml;
 
-import jdk.nashorn.api.scripting.JSObject;
+import org.openjdk.nashorn.api.scripting.JSObject;
 
 public class MjmlProcessorResult {
 


### PR DESCRIPTION
Hi,
i wanted to use mjml-processor in a java17 project so i had to make some changes as nashorn is not published with java anymore starting with java 15. (was deprecated in java 11). 
I though a PR might be appreciated so here it is

Brief overview over the changes:
- Update Gradle to Version 7.4.
- Use openJDK nashorn version instead of deprecated version bundled in jdk. (this will break in java14+)
- Propagate AssertionErrors in threaded test to main thread to assure propper handling by junit
- Ignore Line endings in tests to make tests multiPlatform compatible
- bump compatibility version to java 17
- remove deprecated maven plugin